### PR TITLE
Replace 'static lifetime on the value in kv::set with parameterized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ url = "2.2.2"
 dockertest-server = { version = "0.1.4", features=["hashi"] }
 env_logger = "0.9.0"
 futures = "0.3.17"
-test-env-log = { version = "0.2.7", features = ["trace"] }
+test-log = { version = "0.2.8", features = ["trace"] }
 tokio = { version = "1.12.0", features = ["full"] }
 tokio-test = "0.4.2"
 tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -159,7 +159,7 @@ pub async fn read_json_raw<T: DeserializeOwned, C: Client>(
 pub async fn set<'a>(
     client: &'a impl Client,
     key: &'a str,
-    value: &'static [u8],
+    value: &'a [u8],
     opts: Option<&'a mut SetKeyRequestBuilder>,
 ) -> Result<ApiResponse<bool>, ClientError> {
     let mut t = SetKeyRequest::builder();

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -9,7 +9,7 @@ use consulrs::{
     catalog,
     client::Client,
 };
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test() {

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{ConsulServer, ConsulServerHelper, CountingServer};
 use consulrs::{api::check::requests::RegisterCheckRequest, check, client::Client};
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test() {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,8 +17,8 @@ pub use dockertest_server::servers::hashi::{
 use dockertest_server::Test;
 
 pub const CHECK_NAME: &str = "health";
-pub const CONSUL_PORT: u32 = 9500;
-pub const COUNTING_PORT: u32 = 9100;
+pub const CONSUL_PORT: u32 = 9201;
+pub const COUNTING_PORT: u32 = 9200;
 pub const SERVICE_NAME: &str = "counting";
 pub const VERSION: &str = "1.9.9";
 

--- a/tests/kv.rs
+++ b/tests/kv.rs
@@ -1,9 +1,10 @@
 mod common;
 
 use common::{ConsulServer, ConsulServerHelper};
-use consulrs::{client::Client, kv};
+use consulrs::{api::kv::common::KVPair, api::kv::requests, client::Client, kv};
 use serde::{Deserialize, Serialize};
-use test_env_log::test;
+use std::convert::TryInto;
+use test_log::test;
 
 #[derive(Deserialize, Serialize)]
 struct TestObject {
@@ -21,9 +22,11 @@ fn test() {
         test_set(&client, key).await;
         test_keys(&client).await;
         test_read(&client, key).await;
+        test_read_recurse(&client, key).await;
         test_read_raw(&client, key).await;
         test_delete(&client, key).await;
         test_json(&client, key).await;
+        test_roundtrip_bytes(&client, key).await;
     });
 }
 
@@ -63,5 +66,38 @@ async fn test_read(client: &impl Client, key: &str) {
 
 async fn test_set(client: &impl Client, key: &str) {
     let res = kv::set(client, key, b"test", None).await;
+    assert!(res.is_ok());
+}
+
+fn read_response_to_value(mut response: Vec<KVPair>) -> Vec<u8> {
+    response
+        .pop()
+        .and_then(|v| v.value)
+        .unwrap()
+        .try_into()
+        .unwrap()
+}
+
+async fn test_roundtrip_bytes(client: &impl Client, key: &str) {
+    let res = kv::set(client, key, b"test", None).await;
+    assert!(res.is_ok());
+
+    let res = kv::read(client, key, None).await;
+    assert!(res.is_ok());
+
+    let res = res.unwrap();
+    assert_eq!(res.response.len(), 1);
+
+    let bytes: Vec<u8> = read_response_to_value(res.response);
+    assert_eq!(bytes, b"test");
+}
+
+async fn test_read_recurse(client: &impl Client, key: &str) {
+    let res = kv::read(
+        client,
+        key,
+        Some(requests::ReadKeyRequestBuilder::default().recurse(true)),
+    )
+    .await;
     assert!(res.is_ok());
 }

--- a/tests/service.rs
+++ b/tests/service.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{ConsulServer, ConsulServerHelper, CountingServer};
 use consulrs::{client::Client, service};
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test() {

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{ConsulServer, ConsulServerHelper};
 use consulrs::{api::session::requests::CreateSessionRequest, client::Client, session};
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test() {

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{ConsulServer, ConsulServerHelper};
 use consulrs::{client::Client, snapshot};
-use test_env_log::test;
+use test_log::test;
 
 #[test]
 fn test() {


### PR DESCRIPTION
Requiring that the `value` of the bytes passed into kv::set makes this
API difficult to practically use, it need only outlive `kv::set`.
Consider a common example of serialization of an object prior to
inserting into the consul kv store.

```
let bytes = serialize_to_bytes(object); // Temporary lifetime
kv::set(&client, "key", &bytes, None).await;
```

Additionally (1) introduced tests for validating sending bytes roundtrip
and using recurse in the kv tests, (2) replaced test_env_log with
test_log as test_env_log was deprecated in favor of test_log.