### PR TITLE
Make rustls-tls an optional feature for reqwest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ tokio-test = "0.4.2"
 tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}
 
 [features]
-default = ["reqwest/default-tls"]
+default = ["reqwest/default-tls", "rustify/default"]
 rustls-tls = ["reqwest/rustls-tls", "rustify/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ tracing-subscriber = {version = "0.2.17", default-features = false, features = [
 
 [features]
 default = ["reqwest/default-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "rustify/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.13.0"
 consulrs_derive = { version = "0.1.0", path = "consulrs_derive" }
 derive_builder = "0.10.2"
 http = "0.2.5"
-reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.4", default-features = false }
 rustify = "0.5.2"
 rustify_derive = "0.5.2"
 serde = "1.0.130"
@@ -38,3 +38,7 @@ test-log = { version = "0.2.8", features = ["trace"] }
 tokio = { version = "1.12.0", features = ["full"] }
 tokio-test = "0.4.2"
 tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}
+
+[features]
+default = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ consulrs_derive = { version = "0.1.0", path = "consulrs_derive" }
 derive_builder = "0.10.2"
 http = "0.2.5"
 reqwest = { version = "0.11.4", default-features = false }
-rustify = "0.5.2"
+rustify = { version = "0.5.2", default-features = false }
 rustify_derive = "0.5.2"
 serde = "1.0.130"
 serde_json = "1.0.66"


### PR DESCRIPTION
rustls-tls includes a dependency that has a license considered
copyleft (MPL-2.0). To make this library more sound to use under the
MIT license, make rustls-tls an optional feature. This removes the
ability to specify client certs when the `rustls-tls` feature is
disabled. However, tls is enabled with reqwests defaults by default.