### PR TITLE
fix ServiceHealthByIdRequest

### DIFF
--- a/src/api/service/requests.rs
+++ b/src/api/service/requests.rs
@@ -83,7 +83,7 @@ pub struct ServiceHealthRequest {
 ///
 /// * Path: agent/health/service/id/{self.id}
 /// * Method: GET
-/// * Response: [Vec<AgentServiceChecksInfo>]
+/// * Response: [AgentServiceChecksInfo]
 /// * Reference: https://www.consul.io/api-docs/agent/service#get-local-service-health-by-its-id
 #[derive(Builder, Debug, Default, Endpoint, QueryEndpoint)]
 #[endpoint(

--- a/src/api/service/requests.rs
+++ b/src/api/service/requests.rs
@@ -88,7 +88,7 @@ pub struct ServiceHealthRequest {
 #[derive(Builder, Debug, Default, Endpoint, QueryEndpoint)]
 #[endpoint(
     path = "agent/health/service/id/{self.id}",
-    response = "Vec<AgentServiceChecksInfo>",
+    response = "AgentServiceChecksInfo",
     builder = "true"
 )]
 #[builder(setter(into, strip_option), default)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -55,7 +55,7 @@ pub async fn health_by_id(
     client: &impl Client,
     id: &str,
     opts: Option<&mut ServiceHealthByIdRequestBuilder>,
-) -> Result<ApiResponse<Vec<AgentServiceChecksInfo>>, ClientError> {
+) -> Result<ApiResponse<AgentServiceChecksInfo>, ClientError> {
     let mut t = ServiceHealthByIdRequest::builder();
     let endpoint = opts.unwrap_or(&mut t).id(id).build().unwrap();
     api::exec_with_result(client, endpoint).await


### PR DESCRIPTION
https://www.consul.io/api-docs/agent/service#get-local-service-health-by-its-id return a single entity, not a vector